### PR TITLE
Fix NullReferenceException Under Release Configuration #134 #119 (/≧▽≦)/

### DIFF
--- a/WzComparerR2.Common/Config/ConfigManager.cs
+++ b/WzComparerR2.Common/Config/ConfigManager.cs
@@ -6,6 +6,7 @@ using System.Configuration;
 using System.IO;
 using System.Windows.Forms;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace WzComparerR2.Config
 {
@@ -67,6 +68,10 @@ namespace WzComparerR2.Config
             return false;
         }
 
+        /// <summary>
+        /// 对此方法的调用不应为尾调用, 否则<see cref="Assembly.GetCallingAssembly"/>会因尾调用优化出错.
+        /// </summary>
+        /// <seealso cref="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getcallingassembly?redirectedfrom=MSDN&view=netcore-3.1#System_Reflection_Assembly_GetCallingAssembly"/>
         public static void RegisterAllSection()
         {
             var asm = Assembly.GetCallingAssembly();

--- a/WzComparerR2.LuaConsole/FrmConsole.cs
+++ b/WzComparerR2.LuaConsole/FrmConsole.cs
@@ -32,6 +32,8 @@ namespace WzComparerR2.LuaConsole
         Thread executeThread;
         bool isRunning;
 
+        //NoInlining防止Assembly.GetCallingAssembly因尾调用优化出错
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private void InitLuaEnv()
         {
             lua = new Lua();

--- a/WzComparerR2.LuaConsole/FrmConsole.cs
+++ b/WzComparerR2.LuaConsole/FrmConsole.cs
@@ -19,6 +19,8 @@ namespace WzComparerR2.LuaConsole
 {
     public partial class FrmConsole : DevComponents.DotNetBar.Office2007Form
     {
+        //NoOptimization防止Assembly.GetCallingAssembly因尾调用优化出错
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
         public FrmConsole()
         {
             InitializeComponent();
@@ -32,8 +34,6 @@ namespace WzComparerR2.LuaConsole
         Thread executeThread;
         bool isRunning;
 
-        //NoInlining防止Assembly.GetCallingAssembly因尾调用优化出错
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private void InitLuaEnv()
         {
             lua = new Lua();

--- a/WzComparerR2.MapRender/Entry.cs
+++ b/WzComparerR2.MapRender/Entry.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Text;
 using WzComparerR2.WzLib;
 using WzComparerR2.Common;
@@ -31,7 +30,7 @@ namespace WzComparerR2.MapRender
         private ButtonItem btnItemMapRenderV2;
         private FrmMapRender2 mapRenderGame2;
 
-        [MethodImpl(MethodImplOptions.NoOptimization)]
+        
         protected override void OnLoad()
         {
             #if MapRenderV1
@@ -40,13 +39,11 @@ namespace WzComparerR2.MapRender
             btnItemMapRender.Click += btnItem_Click;
             bar.Items.Add(btnItemMapRender);
             #endif
-
+            ConfigManager.RegisterAllSection();
             this.bar2 = Context.AddRibbonBar("Modules", "MapRender2");
             btnItemMapRenderV2 = new ButtonItem("", "MapRenderV2");
             btnItemMapRenderV2.Click += btnItem_Click;
             bar2.Items.Add(btnItemMapRenderV2);
-
-            ConfigManager.RegisterAllSection();
         }
 
         void btnItem_Click(object sender, EventArgs e)

--- a/WzComparerR2.MapRender/Entry.cs
+++ b/WzComparerR2.MapRender/Entry.cs
@@ -30,7 +30,6 @@ namespace WzComparerR2.MapRender
         private ButtonItem btnItemMapRenderV2;
         private FrmMapRender2 mapRenderGame2;
 
-        
         protected override void OnLoad()
         {
             #if MapRenderV1
@@ -39,11 +38,11 @@ namespace WzComparerR2.MapRender
             btnItemMapRender.Click += btnItem_Click;
             bar.Items.Add(btnItemMapRender);
             #endif
-            ConfigManager.RegisterAllSection();
             this.bar2 = Context.AddRibbonBar("Modules", "MapRender2");
             btnItemMapRenderV2 = new ButtonItem("", "MapRenderV2");
             btnItemMapRenderV2.Click += btnItem_Click;
             bar2.Items.Add(btnItemMapRenderV2);
+            ConfigManager.RegisterAllSection();
         }
 
         void btnItem_Click(object sender, EventArgs e)

--- a/WzComparerR2.MapRender/Entry.cs
+++ b/WzComparerR2.MapRender/Entry.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 using WzComparerR2.WzLib;
 using WzComparerR2.Common;
@@ -30,6 +31,7 @@ namespace WzComparerR2.MapRender
         private ButtonItem btnItemMapRenderV2;
         private FrmMapRender2 mapRenderGame2;
 
+        [MethodImpl(MethodImplOptions.NoOptimization)]
         protected override void OnLoad()
         {
             #if MapRenderV1

--- a/WzComparerR2.Network/Contracts/TypeNameBinder.cs
+++ b/WzComparerR2.Network/Contracts/TypeNameBinder.cs
@@ -13,8 +13,10 @@ namespace WzComparerR2.Network.Contracts
         readonly Dictionary<Type, string> knownTypeNames = new Dictionary<Type, string>();
         readonly Dictionary<string, Type> knownTypes = new Dictionary<string, Type>();
 
-        //NoInlining防止Assembly.GetCallingAssembly因尾调用优化出错
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        /// <summary>
+        /// 对此构造器的调用不应为尾调用, 否则<see cref="Assembly.GetCallingAssembly"/>会因尾调用优化出错.
+        /// </summary>
+        /// <seealso cref="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getcallingassembly?redirectedfrom=MSDN&view=netcore-3.1#System_Reflection_Assembly_GetCallingAssembly"/>
         public TypeNameBinder()
         {
             var types = Assembly.GetCallingAssembly().GetTypes()

--- a/WzComparerR2.Network/Contracts/TypeNameBinder.cs
+++ b/WzComparerR2.Network/Contracts/TypeNameBinder.cs
@@ -13,6 +13,8 @@ namespace WzComparerR2.Network.Contracts
         readonly Dictionary<Type, string> knownTypeNames = new Dictionary<Type, string>();
         readonly Dictionary<string, Type> knownTypes = new Dictionary<string, Type>();
 
+        //NoInlining防止Assembly.GetCallingAssembly因尾调用优化出错
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         public TypeNameBinder()
         {
             var types = Assembly.GetCallingAssembly().GetTypes()

--- a/WzComparerR2/WzComparerR2.csproj
+++ b/WzComparerR2/WzComparerR2.csproj
@@ -372,8 +372,8 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy "$(SolutionDir)References\x86\*" "$(TargetDir)Lib\x86" /Y /I
-xcopy "$(SolutionDir)References\x64\*" "$(TargetDir)Lib\x64" /Y /I</PostBuildEvent>
+    <PostBuildEvent>xcopy "$(ProjectDir)..\References\x86\*" "$(TargetDir)Lib\x86" /Y /I
+xcopy "$(ProjectDir)..\References\x64\*" "$(TargetDir)Lib\x64" /Y /I</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Bug reported: #134 #119 

**Reproduction Steps**: 
see https://github.com/Kagamia/WzComparerR2/issues/119#issuecomment-642542828

**Investigation:**
NullReferenceException was thrown because there is no `<WcR2.MapRender>` entry in Setting.config. And that's is because calling of `ConfigManager.RegisterAllSection()` was wiped out by compiler.

**Fix**
Add `[MethodImpl(MethodImplOptions.NoOptimization)]` attribute to forbidden optimization. 

**Note**
`WzComparerR2/WzComparerR2.csproj ` after-build event is changed to use `$(ProjectDir)` for easier integration to other solution. 

（用WzComparer四年了终于提交了第一个PR  ~~>_<~~）
编译器优化导致了`ConfigManager.RegisterAllSection()`没被调用，应该是奇怪的生成后复制导致的。Roslyn自动复制依赖的话应该不会有这种问题……………………先这么修复一下吧

另外夹带了一个私货：WzComparerR2.csproj 生成后事件的路径改用`$(ProjectDir)` ，这样的话项目可以被其他的解决方案包含

如果作者大大乐意的话我可以帮忙做一些微小的工作哟~比如说把外部依赖项改成用NuGet管理，可以用腾讯的NuGet源：https://mirrors.cloud.tencent.com/nuget/
这样显得正规点=w=