### PR TITLE
Fix ItemTooltip using icon height instead of origin Y

### DIFF
--- a/WzComparerR2/CharaSimControl/ItemTooltipRender2.cs
+++ b/WzComparerR2/CharaSimControl/ItemTooltipRender2.cs
@@ -316,7 +316,7 @@ namespace WzComparerR2.CharaSimControl
             {
                 g.DrawImage(GearGraphics.EnlargeBitmap(item.Icon.Bitmap),
                 iconX + 6 + (1 - item.Icon.Origin.X) * 2,
-                picH + 6 + (33 - item.Icon.Bitmap.Height) * 2);
+                picH + 6 + (33 - item.Icon.Origin.Y) * 2);
             }
             if (item.Cash)
             {


### PR DESCRIPTION
In ItemTooltipRender2.cs, drawing icon uses height instead of origin Y.

```diff
            if (item.Icon.Bitmap != null)
            {
                g.DrawImage(GearGraphics.EnlargeBitmap(item.Icon.Bitmap),
                iconX + 6 + (1 - item.Icon.Origin.X) * 2,
-               picH + 6 + (33 - item.Icon.Bitmap.Height) * 2);
+               picH + 6 + (33 - item.Icon.Origin.Y) * 2);
            }
```

Check KENNYSOFT/WzComparerR2#52 for Before/After.