### PR TITLE
Fix NullReferenceException of MapRender Under Release Configuration (Fix #119)

### DIFF
--- a/WzComparerR2.MapRender/Entry.cs
+++ b/WzComparerR2.MapRender/Entry.cs
@@ -30,6 +30,8 @@ namespace WzComparerR2.MapRender
         private ButtonItem btnItemMapRenderV2;
         private FrmMapRender2 mapRenderGame2;
 
+        //NoOptimization防止Assembly.GetCallingAssembly因尾调用优化出错
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
         protected override void OnLoad()
         {
             #if MapRenderV1


### PR DESCRIPTION
https://github.com/Kagamia/WzComparerR2/issues/119#issuecomment-703217662

> Still occurs in MapRender of WzComparerR2.anycpu.exe