### PR TITLE
UI: Escape invalid file name characters

### DIFF
--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -565,7 +565,7 @@ namespace WzComparerR2
 
                 if (config.AutoSaveEnabled)
                 {
-                    pngFileName = Path.Combine(config.AutoSavePictureFolder, pngFileName);
+                    pngFileName = Path.Combine(config.AutoSavePictureFolder, string.Join("_", pngFileName.Split(Path.GetInvalidFileNameChars(), StringSplitOptions.None)));
                 }
                 else
                 {
@@ -604,7 +604,7 @@ namespace WzComparerR2
 
             if (config.AutoSaveEnabled)
             {
-                var fullFileName = Path.Combine(config.AutoSavePictureFolder, aniFileName);
+                var fullFileName = Path.Combine(config.AutoSavePictureFolder, string.Join("_", aniFileName.Split(Path.GetInvalidFileNameChars(), StringSplitOptions.None)));
                 int i = 1;
                 while (File.Exists(fullFileName))
                 {


### PR DESCRIPTION
If you turned on the auto-saving feature and try to save a file whose path contains ':' or something that you cannot use as the file name in the file system, it just fails.

![image](https://user-images.githubusercontent.com/6624567/132132561-7a266130-980e-4cab-9a01-9b9ee748477e.png)

So this patch just replaces unusable characters to underscore(_). The below screenshot is showing that auto-save is successful after auto escaping.

![image](https://user-images.githubusercontent.com/6624567/132132654-b536d8f5-bd4e-4b6d-bd11-471d26525c1b.png)