### PR TITLE
UI: Show MergedVersion in Wz detail listview

### DIFF
--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -927,7 +927,7 @@ namespace WzComparerR2
                 listViewExWzDetail.Items.Add(new ListViewItem(new string[] { "File Name", wzFile.Header.FileName }));
                 listViewExWzDetail.Items.Add(new ListViewItem(new string[] { "File Size", wzFile.Header.FileSize + " bytes" }));
                 listViewExWzDetail.Items.Add(new ListViewItem(new string[] { "Copyright", wzFile.Header.Copyright }));
-                listViewExWzDetail.Items.Add(new ListViewItem(new string[] { "Version", wzFile.Header.WzVersion.ToString() }));
+                listViewExWzDetail.Items.Add(new ListViewItem(new string[] { "Version", wzFile.GetMergedVersion().ToString() }));
                 listViewExWzDetail.Items.Add(new ListViewItem(new string[] { "Wz Type", wzFile.IsSubDir ? "SubDir" : wzFile.Type.ToString() }));
 
                 foreach (Wz_File subFile in wzFile.MergedWzFiles)


### PR DESCRIPTION
As you know, since some Wz types (ex. Effect) does not have any img in the root but in SubDirs, we cannot determine root Wz version. So this PR makes WzComparerR2 show `MergedVersion` in Wz detail listview.

![before](https://user-images.githubusercontent.com/6624567/133966947-2d1d04ec-7201-438a-ae6e-e4fa0eeb86c6.png)

▲ Before

![after](https://user-images.githubusercontent.com/6624567/133966970-729b7243-b43c-485b-88de-bc852fc7127f.png)

▲ After