### PR TITLE
Patcher: Find old checksum when using KMST1125 patch format

### DIFF
--- a/WzComparerR2/Patcher/WzPatcher.cs
+++ b/WzComparerR2/Patcher/WzPatcher.cs
@@ -171,6 +171,11 @@ namespace WzComparerR2.Patcher
                     break;
                 }
 
+                if (this.IsKMST1125Format.Value && this.oldFileHash.TryGetValue(part.FileName, out uint value))
+                {
+                    part.OldChecksum = value;
+                }
+
                 patchParts.Add(part);
 
                 //跳过当前段


### PR DESCRIPTION
KMST1125 patch format centralized old file hashes, so this PR makes Patcher find old checksum from the dictionary. It's showed when doing PrePatch.

![image](https://user-images.githubusercontent.com/6624567/133967330-35d5a88a-44f2-4ceb-9cf1-20f18093afb0.png)