### PR TITLE
WzLib: Speedup for KMST1132 wz format

### DIFF
--- a/WzComparerR2.WzLib/Wz_File.cs
+++ b/WzComparerR2.WzLib/Wz_File.cs
@@ -169,6 +169,7 @@ namespace WzComparerR2.WzLib
             {
                 // not sure if nexon will change this magic version, just hard coded.
                 this.Header.SetWzVersion(777);
+                this.Header.VersionChecked = true;
             }
             else
             {


### PR DESCRIPTION
We don't know 777 will be last forever, but for now, we assume that 777 is the only correct version. So set `VersionChecked` flag as true to speed up loading KMS 357+ client.

(KMS client loading is currently sooooooo slow now because of some large wz files having only one img, like Skill014.wz, Skill015.wz ...)

In my experiment, this effects approximately 20x. (10s → 0.5s) But not effects to KMS 354-356.

BTW, FYI: In the patch KMS 357 → 358, wz files are not changed at all. 🤣