### PR TITLE
Adding EnableDarkMode, a toggle for EasyComparer

### DIFF
--- a/WzComparerR2/Comparer/EasyComparer.cs
+++ b/WzComparerR2/Comparer/EasyComparer.cs
@@ -22,7 +22,7 @@ namespace WzComparerR2.Comparer
         public bool OutputPng { get; set; }
         public bool OutputAddedImg { get; set; }
         public bool OutputRemovedImg { get; set; }
-        
+        public bool EnableDarkMode { get; set; }
         public string StateInfo
         {
             get { return stateInfo; }
@@ -214,6 +214,7 @@ namespace WzComparerR2.Comparer
                     this.OutputPng ? "-OutputPng" : null,
                     this.OutputAddedImg ? "-OutputAddedImg" : null,
                     this.OutputRemovedImg ? "-OutputRemovedImg" : null,
+                    this.EnableDarkMode ? "-EnableDarkMode" : null,
                     "-PngComparison " + this.Comparer.PngComparison,
                     this.Comparer.ResolvePngLink ? "-ResolvePngLink" : null,
                 }.Where(p => p != null)));
@@ -508,24 +509,46 @@ namespace WzComparerR2.Comparer
 
         public virtual void CreateStyleSheet(string outputDir)
         {
+
             string path = Path.Combine(outputDir, "style.css");
             if (File.Exists(path))
                 return;
             FileStream fs = new FileStream(path, FileMode.Create, FileAccess.Write);
             StreamWriter sw = new StreamWriter(fs, Encoding.UTF8);
-            sw.WriteLine("body { font-size:12px; }");
-            sw.WriteLine("p.wzf { }");
-            sw.WriteLine("table, tr, th, td { border:1px solid #ff8000; border-collapse:collapse; }");
-            sw.WriteLine("table { margin-bottom:16px; }");
-            sw.WriteLine("th { text-align:left; }");
-            sw.WriteLine("table.lst0 { }");
-            sw.WriteLine("table.lst1 { }");
-            sw.WriteLine("table.lst2 { }");
-            sw.WriteLine("table.img { }");
-            sw.WriteLine("table.img tr.r0 { background-color:#fff4c4; }");
-            sw.WriteLine("table.img tr.r1 { background-color:#ebf2f8; }");
-            sw.WriteLine("table.img tr.r2 { background-color:#ffffff; }");
-            sw.WriteLine("table.img.noChange { display:none; }");
+            if (EnableDarkMode)
+            {
+
+                sw.WriteLine("body { font-size:12px; background-color:black; color:white; }");
+                sw.WriteLine("a { color:white; }");
+                sw.WriteLine("p.wzf { }");
+                sw.WriteLine("table, tr, th, td { border:1px solid #ff8000; border-collapse:collapse; }");
+                sw.WriteLine("table { margin-bottom:16px; }");
+                sw.WriteLine("th { text-align:left; }");
+                sw.WriteLine("table.lst0 { }");
+                sw.WriteLine("table.lst1 { }");
+                sw.WriteLine("table.lst2 { }");
+                sw.WriteLine("table.img { }");
+                sw.WriteLine("table.img tr.r0 { background-color:#003049; }");
+                sw.WriteLine("table.img tr.r1 { background-color:#000000; }");
+                sw.WriteLine("table.img tr.r2 { background-color:#462306; }");
+                sw.WriteLine("table.img.noChange { display:none; }");
+            }
+            else
+            {
+                sw.WriteLine("body { font-size:12px; }");
+                sw.WriteLine("p.wzf { }");
+                sw.WriteLine("table, tr, th, td { border:1px solid #ff8000; border-collapse:collapse; }");
+                sw.WriteLine("table { margin-bottom:16px; }");
+                sw.WriteLine("th { text-align:left; }");
+                sw.WriteLine("table.lst0 { }");
+                sw.WriteLine("table.lst1 { }");
+                sw.WriteLine("table.lst2 { }");
+                sw.WriteLine("table.img { }");
+                sw.WriteLine("table.img tr.r0 { background-color:#fff4c4; }");
+                sw.WriteLine("table.img tr.r1 { background-color:#ebf2f8; }");
+                sw.WriteLine("table.img tr.r2 { background-color:#ffffff; }");
+                sw.WriteLine("table.img.noChange { display:none; }");
+            }
             sw.Flush();
             sw.Close();
         }

--- a/WzComparerR2/FrmPatcher.Designer.cs
+++ b/WzComparerR2/FrmPatcher.Designer.cs
@@ -44,6 +44,7 @@
             this.expandablePanel1 = new DevComponents.DotNetBar.ExpandablePanel();
             this.buttonXCheck = new DevComponents.DotNetBar.ButtonX();
             this.expandablePanel2 = new DevComponents.DotNetBar.ExpandablePanel();
+            this.chkEnableDarkMode = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.chkOutputRemovedImg = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.chkOutputAddedImg = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.cmbComparePng = new DevComponents.DotNetBar.Controls.ComboBoxEx();
@@ -340,6 +341,7 @@
             this.expandablePanel2.CanvasColor = System.Drawing.SystemColors.Control;
             this.expandablePanel2.ColorSchemeStyle = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
             this.expandablePanel2.Controls.Add(this.chkResolvePngLink);
+            this.expandablePanel2.Controls.Add(this.chkEnableDarkMode);
             this.expandablePanel2.Controls.Add(this.chkOutputRemovedImg);
             this.expandablePanel2.Controls.Add(this.chkOutputAddedImg);
             this.expandablePanel2.Controls.Add(this.cmbComparePng);
@@ -378,6 +380,22 @@
             this.expandablePanel2.TitleStyle.GradientAngle = 90;
             this.expandablePanel2.TitleText = "Manual Patcher";
             // 
+            // chkEnableDarkMode
+            // 
+            this.chkEnableDarkMode.AutoSize = true;
+            this.chkEnableDarkMode.BackColor = System.Drawing.Color.Transparent;
+            // 
+            // 
+            // 
+            this.chkEnableDarkMode.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square;
+            this.chkEnableDarkMode.Location = new System.Drawing.Point(253, 135);
+            this.chkEnableDarkMode.Name = "chkEnableDarkMode";
+            this.chkEnableDarkMode.Size = new System.Drawing.Size(125, 16);
+            this.chkEnableDarkMode.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.superTooltip1.SetSuperTooltip(this.chkEnableDarkMode, new DevComponents.DotNetBar.SuperTooltipInfo("EnableDarkMode", "", "Outputs the comparison with dark mode HTML.", null, null, DevComponents.DotNetBar.eTooltipColor.System, true, false, new System.Drawing.Size(180, 60)));
+            this.chkEnableDarkMode.TabIndex = 14;
+            this.chkEnableDarkMode.Text = "EnableDarkMode";
+            // 
             // chkOutputRemovedImg
             // 
             this.chkOutputRemovedImg.AutoSize = true;
@@ -386,7 +404,7 @@
             // 
             // 
             this.chkOutputRemovedImg.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square;
-            this.chkOutputRemovedImg.Location = new System.Drawing.Point(198, 135);
+            this.chkOutputRemovedImg.Location = new System.Drawing.Point(125, 135);
             this.chkOutputRemovedImg.Name = "chkOutputRemovedImg";
             this.chkOutputRemovedImg.Size = new System.Drawing.Size(125, 16);
             this.chkOutputRemovedImg.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
@@ -402,7 +420,7 @@
             // 
             // 
             this.chkOutputAddedImg.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square;
-            this.chkOutputAddedImg.Location = new System.Drawing.Point(79, 135);
+            this.chkOutputAddedImg.Location = new System.Drawing.Point(6, 135);
             this.chkOutputAddedImg.Name = "chkOutputAddedImg";
             this.chkOutputAddedImg.Size = new System.Drawing.Size(113, 16);
             this.chkOutputAddedImg.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
@@ -968,5 +986,6 @@
         private DevComponents.DotNetBar.Controls.CheckBoxX chkOutputAddedImg;
         private DevComponents.DotNetBar.ButtonX buttonXCreate;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkResolvePngLink;
+        private DevComponents.DotNetBar.Controls.CheckBoxX chkEnableDarkMode;
     }
 }

--- a/WzComparerR2/FrmPatcher.cs
+++ b/WzComparerR2/FrmPatcher.cs
@@ -334,6 +334,7 @@ namespace WzComparerR2
                             comparer.OutputPng = chkOutputPng.Checked;
                             comparer.OutputAddedImg = chkOutputAddedImg.Checked;
                             comparer.OutputRemovedImg = chkOutputRemovedImg.Checked;
+                            comparer.EnableDarkMode = chkEnableDarkMode.Checked;
                             comparer.Comparer.PngComparison = (WzPngComparison)cmbComparePng.SelectedItem;
                             comparer.Comparer.ResolvePngLink = chkResolvePngLink.Checked;
                             wznew.Load(e.Part.TempFilePath, false);

--- a/WzComparerR2/MainForm.Designer.cs
+++ b/WzComparerR2/MainForm.Designer.cs
@@ -198,6 +198,7 @@
             this.superTabItem1 = new DevComponents.DotNetBar.SuperTabItem();
             this.superTabControlPanel2 = new DevComponents.DotNetBar.SuperTabControlPanel();
             this.chkResolvePngLink = new DevComponents.DotNetBar.Controls.CheckBoxX();
+            this.chkEnableDarkMode = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.chkOutputRemovedImg = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.chkOutputAddedImg = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.labelX1 = new DevComponents.DotNetBar.LabelX();
@@ -2302,6 +2303,7 @@
             // 
             // superTabControlPanel2
             // 
+            this.superTabControlPanel2.Controls.Add(this.chkEnableDarkMode);
             this.superTabControlPanel2.Controls.Add(this.chkResolvePngLink);
             this.superTabControlPanel2.Controls.Add(this.chkOutputRemovedImg);
             this.superTabControlPanel2.Controls.Add(this.chkOutputAddedImg);
@@ -2330,6 +2332,19 @@
             this.chkResolvePngLink.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
             this.chkResolvePngLink.TabIndex = 9;
             this.chkResolvePngLink.Text = "ResolvePngLink";
+            // 
+            // chkEnableDarkMode
+            // 
+            // 
+            // 
+            // 
+            this.chkEnableDarkMode.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square;
+            this.chkEnableDarkMode.Location = new System.Drawing.Point(280, 61);
+            this.chkEnableDarkMode.Name = "chkEnableDarkMode";
+            this.chkEnableDarkMode.Size = new System.Drawing.Size(135, 23);
+            this.chkEnableDarkMode.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.chkEnableDarkMode.TabIndex = 9;
+            this.chkEnableDarkMode.Text = "EnableDarkMode";
             // 
             // chkOutputRemovedImg
             // 
@@ -3173,5 +3188,6 @@
         private DevComponents.DotNetBar.ButtonItem buttonItemSaveWithOptions;
         private DevComponents.DotNetBar.CheckBoxItem checkBoxItemRegex1;
         private DevComponents.DotNetBar.CheckBoxItem checkBoxItemRegex2;
+        private DevComponents.DotNetBar.Controls.CheckBoxX chkEnableDarkMode;
     }
 }

--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -2892,6 +2892,7 @@ namespace WzComparerR2
                     comparer.OutputPng = chkOutputPng.Checked;
                     comparer.OutputAddedImg = chkOutputAddedImg.Checked;
                     comparer.OutputRemovedImg = chkOutputRemovedImg.Checked;
+                    comparer.EnableDarkMode = chkEnableDarkMode.Checked;
                     comparer.StateInfoChanged += new EventHandler(comparer_StateInfoChanged);
                     comparer.StateDetailChanged += new EventHandler(comparer_StateDetailChanged);
                     try


### PR DESCRIPTION
So I added a new EnableDarkMode checkbox to both the EasyCompare and the Patcher:

![image](https://user-images.githubusercontent.com/34289651/150261534-405f4454-0f75-4c72-8d93-06001593dfec.png)

![image](https://user-images.githubusercontent.com/34289651/150261427-3b90798d-d4e4-4909-a16a-bf6542ee3bb0.png)


What it does is change the HTML for comparison reports into a Dark Mode setting, for example:
![image](https://user-images.githubusercontent.com/34289651/150261580-1e202f2a-3428-4b6f-a490-3c56126684cf.png)

Black = newly added, red = removed, blue = changed
