### PR TITLE
WzLib: Fix legal node name regex

### DIFF
--- a/WzComparerR2.WzLib/Wz_Crypto.cs
+++ b/WzComparerR2.WzLib/Wz_Crypto.cs
@@ -157,7 +157,7 @@ namespace WzComparerR2.WzLib
 
         private bool IsLegalNodeName(string nodeName)
         {
-            return nodeName.EndsWith(".img") || Regex.IsMatch(nodeName, @"^[A-Za-z-9_]+$");
+            return nodeName.EndsWith(".img") || nodeName.EndsWith(".lua") || Regex.IsMatch(nodeName, @"^[A-Za-z0-9_]+$");
         }
 
         static readonly byte[] iv_gms = { 0x4d, 0x23, 0xc7, 0x2b };


### PR DESCRIPTION
If you open Data\Map\Map\Map.wz (NOT Data\Map\Map.wz) of KMS 360, the error occurs:

![image](https://user-images.githubusercontent.com/6624567/155085453-30751285-08e2-4f97-a4fe-694f0cf428ea.png)

I debugged and found out that it failed with the existing node name 'Map0'. Also, '.lua' can be a legal suffix.