### PR TITLE
Adding minimap-enabled mob feature

### DIFF
--- a/WzComparerR2.MapRender/FrmMapRender2.SceneManager.cs
+++ b/WzComparerR2.MapRender/FrmMapRender2.SceneManager.cs
@@ -414,6 +414,18 @@ namespace WzComparerR2.MapRender
                     });
                 }
             }
+            foreach (var mob in mapData.Scene.Mobs)
+            {
+                var mobNode = PluginManager.FindWz(string.Format("Mob/{0:D7}.img/info", mob.ID));
+                if ((mobNode?.Nodes["minimap"].GetValueEx(0) ?? 0) != 0)
+                {
+                    this.ui.Minimap.Icons.Add(new UIMinimap2.MapIcon()
+                    {
+                        IconType = UIMinimap2.IconType.Another,
+                        WorldPosition = new EmptyKeys.UserInterface.PointF(mob.X, mob.Y)
+                    });
+                }
+            }
 
             if (mapData.MiniMap.Width > 0 && mapData.MiniMap.Height > 0)
             {

--- a/WzComparerR2.MapRender/MapScene.cs
+++ b/WzComparerR2.MapRender/MapScene.cs
@@ -38,6 +38,12 @@ namespace WzComparerR2.MapRender
             .Where(lifeNode => lifeNode.Type == LifeItem.LifeType.Npc && !lifeNode.Hide)
             .Concat(this.Fly.Sky.Slots.OfType<LifeItem>()
             .Where(lifeNode => lifeNode.Type == LifeItem.LifeType.Npc && !lifeNode.Hide));
+        public IEnumerable<LifeItem> Mobs => this.Layers.Nodes.OfType<LayerNode>()
+                    .SelectMany(layerNode => layerNode.Foothold.Nodes).OfType<ContainerNode<FootholdItem>>()
+                    .SelectMany(fhNode => fhNode.Slots).OfType<LifeItem>()
+                    .Where(lifeNode => lifeNode.Type == LifeItem.LifeType.Mob && !lifeNode.Hide)
+                    .Concat(this.Fly.Sky.Slots.OfType<LifeItem>()
+                    .Where(lifeNode => lifeNode.Type == LifeItem.LifeType.Mob && !lifeNode.Hide));
 
         public PortalItem FindPortal(string pName)
         {

--- a/WzComparerR2.MapRender/UI/UIMinimap2.cs
+++ b/WzComparerR2.MapRender/UI/UIMinimap2.cs
@@ -452,6 +452,17 @@ namespace WzComparerR2.MapRender.UI
                                 }
                             }
                             break;
+
+                        case IconType.Another:
+                            {
+                                var texture = this.FindResource("another") as TextureBase;
+                                if (texture != null)
+                                {
+                                    var rect = drawIconFunc(texture, icon.WorldPosition);
+                                    iconRectCache.Add(new IconRect() { Rect = rect, Tooltip = icon.Tooltip });
+                                }
+                            }
+                            break;
                     }
                 }
 
@@ -495,6 +506,7 @@ namespace WzComparerR2.MapRender.UI
                     addResource("shop");
                     addResource("trunk");
                     addResource("arrowup");
+                    addResource("another");
                 }
             }
 
@@ -524,6 +536,7 @@ namespace WzComparerR2.MapRender.UI
             Shop,
             Trunk,
             ArrowUp,
+            Another,
         }
 
         private sealed class UIMinimapResource : INinePatchResource<TextureBase>


### PR DESCRIPTION
I've opened this PR to have the MapRender feature minimap-enabled mobs as red dots, checking for the Mob property "minimap". See the PR for WCR2-KMS below for more details:
https://github.com/KENNYSOFT/WzComparerR2/pull/127

Tested in 3 separate maps, one of the maps in Odium (Map ID 993217170)
![image](https://github.com/Kagamia/WzComparerR2/assets/34289651/be33270b-754b-475c-b757-00f7e833c59c)

Monster Park (Map ID 954104000)
![image](https://github.com/Kagamia/WzComparerR2/assets/34289651/0077c2de-bb79-4817-88cf-3590aede281b)

And a Morass daily quest map (Map ID 940204490)
![image](https://github.com/Kagamia/WzComparerR2/assets/34289651/31496bd7-bc47-4616-a40e-96512d4dabda)
