### PR TITLE
新增功能：Patcher 加入确认下载的提示框

### DIFF
--- a/WzComparerR2/FrmPatcher.cs
+++ b/WzComparerR2/FrmPatcher.cs
@@ -179,15 +179,15 @@ namespace WzComparerR2
                     switch (MessageBoxEx.Show(string.Format("文件大小：{0:N0} bytes, 更新时间：{1:yyyy-MM-dd HH:mm:ss}\n\r是否立即开始下载文件？", item.FileLength, item.LastModified), "Patcher", MessageBoxButtons.YesNo))
                     {
                         case DialogResult.Yes:
-#if NET6_0_OR_GREATER
-            Process.Start(new ProcessStartInfo
-            {
-                UseShellExecute = true,
-                FileName = txtUrl.Text,
-            });
-#else
+                        #if NET6_0_OR_GREATER
+                            Process.Start(new ProcessStartInfo
+                            {
+                                UseShellExecute = true,
+                                FileName = txtUrl.Text,
+                            });
+                        #else
                             Process.Start(txtUrl.Text);
-#endif
+                        #endif
                             return;
 
                         case DialogResult.No:

--- a/WzComparerR2/FrmPatcher.cs
+++ b/WzComparerR2/FrmPatcher.cs
@@ -176,7 +176,7 @@ namespace WzComparerR2
                 item.GetFileLength();
                 if (item.FileLength > 0)
                 {
-                    switch (MessageBoxEx.Show(string.Format("文件大小：{0:N0} bytes, 更新时间：{1:yyyy-MM-dd HH:mm:ss}\n\r是否立即开始下载文件？", item.FileLength, item.LastModified), "Patcher", MessageBoxButtons.YesNo))
+                    switch (MessageBoxEx.Show(string.Format("文件大小：{0:N0} bytes, 更新时间：{1:yyyy-MM-dd HH:mm:ss}\r\n是否立即开始下载文件？", item.FileLength, item.LastModified), "Patcher", MessageBoxButtons.YesNo))
                     {
                         case DialogResult.Yes:
                         #if NET6_0_OR_GREATER

--- a/WzComparerR2/FrmPatcher.cs
+++ b/WzComparerR2/FrmPatcher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;

--- a/WzComparerR2/FrmPatcher.cs
+++ b/WzComparerR2/FrmPatcher.cs
@@ -33,6 +33,7 @@ namespace WzComparerR2
                 settings.Add(new PatcherSetting("KMST", "http://maplestory.dn.nexoncdn.co.kr/PatchT/{1:d5}/{0:d5}to{1:d5}.patch", 2));
                 settings.Add(new PatcherSetting("KMST-Minor", "http://maplestory.dn.nexoncdn.co.kr/PatchT/{0:d5}/Minor/{1:d2}to{2:d2}.patch", 3));
                 settings.Add(new PatcherSetting("KMS", "http://maplestory.dn.nexoncdn.co.kr/Patch/{1:d5}/{0:d5}to{1:d5}.patch", 2));
+                settings.Add(new PatcherSetting("KMS-Minor", "http://maplestory.dn.nexoncdn.co.kr/Patch/{0:d5}/Minor/{1:d2}to{2:d2}.patch", 3));
                 settings.Add(new PatcherSetting("JMS", "http://webdown2.nexon.co.jp/maple/patch/patchdir/{1:d5}/{0:d5}to{1:d5}.patch", 2));
                 settings.Add(new PatcherSetting("GMS", "http://download2.nexon.net/Game/MapleStory/patch/patchdir/{1:d5}/CustomPatch{0}to{1}.exe", 2));
                 settings.Add(new PatcherSetting("TMS", "http://tw.cdnpatch.maplestory.beanfun.com/maplestory/patch/patchdir/{1:d5}/{0:d5}to{1:d5}.patch", 2));
@@ -174,7 +175,23 @@ namespace WzComparerR2
                 item.GetFileLength();
                 if (item.FileLength > 0)
                 {
-                    MessageBoxEx.Show(string.Format("文件大小：{0:N0} bytes, 更新时间：{1:yyyy-MM-dd HH:mm:ss}", item.FileLength, item.LastModified));
+                    switch (MessageBoxEx.Show(string.Format("文件大小：{0:N0} bytes, 更新时间：{1:yyyy-MM-dd HH:mm:ss}\n\r是否立即开始下载文件？", item.FileLength, item.LastModified), "Patcher", MessageBoxButtons.YesNo))
+                    {
+                        case DialogResult.Yes:
+#if NET6_0_OR_GREATER
+            Process.Start(new ProcessStartInfo
+            {
+                UseShellExecute = true,
+                FileName = txtUrl.Text,
+            });
+#else
+                            Process.Start(txtUrl.Text);
+#endif
+                            return;
+
+                        case DialogResult.No:
+                            return;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
为了省去手动复制链接到浏览器的麻烦，故加上了这一功能。
点击 Yes 后，就可以直接调用系统默认浏览器下载 patch 文件。否则，就可以继续像往常一样直接复制链接到浏览器。

另外，由于 KMS 正式服也已经实装 Minor Patch 文件，顺带加上了 KMS-Minor 的链接。