### PR TITLE
Adding quest and questex options in MapRender

### DIFF
--- a/WzComparerR2.MapRender/FrmMapRender2.SceneRendering.cs
+++ b/WzComparerR2.MapRender/FrmMapRender2.SceneRendering.cs
@@ -651,6 +651,10 @@ namespace WzComparerR2.MapRender
             if (item is BackItem)
             {
                 var back = (BackItem)item;
+                if (back.Quest.Exists(quest => !patchVisibility.IsVisible(quest.Item1, quest.Item2)))
+                {
+                    return null;
+                }
                 if (back.IsFront ? patchVisibility.FrontVisible : patchVisibility.BackVisible)
                 {
                     return GetMeshBack(back);
@@ -660,6 +664,14 @@ namespace WzComparerR2.MapRender
             {
                 if (patchVisibility.ObjVisible && !obj.Light)
                 {
+                    if (((ObjItem)item).Quest.Exists(quest => !patchVisibility.IsVisible(quest.Item1, quest.Item2)))
+                    {
+                        return null;
+                    }
+                    if (((ObjItem)item).Questex.Exists(questex => !patchVisibility.IsVisible(questex.Item1, questex.Item2, questex.Item3)))
+                    {
+                        return null;
+                    }
                     return GetMeshObj(obj);
                 }
             }
@@ -695,7 +707,14 @@ namespace WzComparerR2.MapRender
             }
             else if (item is ParticleItem)
             {
-                return GetMeshParticle((ParticleItem)item);
+                if (((ParticleItem)item).Quest.Exists(quest => !patchVisibility.IsVisible(quest.Item1, quest.Item2)))
+                {
+                    return null;
+                }
+                if (patchVisibility.EffectVisible)
+                {
+                    return GetMeshParticle((ParticleItem)item);
+                }
             }
             return null;
         }

--- a/WzComparerR2.MapRender/PatchVisibility.cs
+++ b/WzComparerR2.MapRender/PatchVisibility.cs
@@ -11,6 +11,8 @@ namespace WzComparerR2.MapRender
         {
             this.dictVisible = new Dictionary<RenderObjectType, bool>();
             this.tagsVisible = new SortedDictionary<string, bool>();
+            this.questVisible = new Dictionary<int, int>();
+            this.questexVisible = new Dictionary<Tuple<int, string>, int>();
             foreach (RenderObjectType type in Enum.GetValues(typeof(RenderObjectType)))
             {
                 this.dictVisible[type] = true;
@@ -100,6 +102,12 @@ namespace WzComparerR2.MapRender
             set { this.SetVisible(RenderObjectType.MobName, value); }
         }
 
+        public bool EffectVisible
+        {
+            get { return IsVisible(RenderObjectType.Effect); }
+            set { this.SetVisible(RenderObjectType.Effect, value); }
+        }
+
         public IReadOnlyDictionary<string, bool> TagsVisible
         {
             get { return this.tagsVisible; }
@@ -109,6 +117,8 @@ namespace WzComparerR2.MapRender
 
         private Dictionary<RenderObjectType, bool> dictVisible;
         private SortedDictionary<string, bool> tagsVisible;
+        private Dictionary<int, int> questVisible;
+        private Dictionary<Tuple<int, string>, int> questexVisible;
 
         public bool IsVisible(RenderObjectType type)
         {
@@ -134,7 +144,7 @@ namespace WzComparerR2.MapRender
 
         public void ResetTagVisible(string[] tags)
         {
-            foreach(var tag in tags)
+            foreach (var tag in tags)
             {
                 this.tagsVisible.Remove(tag);
             }
@@ -143,6 +153,56 @@ namespace WzComparerR2.MapRender
         private void SetVisible(RenderObjectType type, bool visible)
         {
             this.dictVisible[type] = visible;
+        }
+
+        public bool IsVisible(int questID, int questState)
+        {
+            int visible;
+            if (!questVisible.TryGetValue(questID, out visible))
+            {
+                return true;
+            }
+            return visible == -1 || visible == questState;
+        }
+
+        public bool IsVisibleExact(int questID, int questState)
+        {
+            int visible;
+            if (!questVisible.TryGetValue(questID, out visible))
+            {
+                return false;
+            }
+            return visible == questState;
+        }
+
+        public void SetVisible(int questID, int questState)
+        {
+            this.questVisible[questID] = questState;
+        }
+
+        public bool IsVisible(int questID, string qkey, int questState)
+        {
+            int visible;
+            if (!questexVisible.TryGetValue(new Tuple<int, string>(questID, qkey), out visible))
+            {
+                return true;
+            }
+            return visible == -1 || visible == questState;
+        }
+
+        public bool IsVisibleExact(int questID, string qkey, int questState)
+        {
+            int visible;
+            if (!questexVisible.TryGetValue(new Tuple<int, string>(questID, qkey), out visible))
+            {
+                return false;
+            }
+            return visible == questState;
+        }
+
+        public void SetVisible(int questID, string qkey, int questState)
+        {
+            this.questexVisible[new Tuple<int, string>(questID, qkey)] = questState;
         }
     }
 }

--- a/WzComparerR2.MapRender/Patches/RenderObjectType.cs
+++ b/WzComparerR2.MapRender/Patches/RenderObjectType.cs
@@ -18,5 +18,6 @@ namespace WzComparerR2.MapRender.Patches
         Front,
         NpcName,
         MobName,
+        Effect,
     }
 }

--- a/WzComparerR2.MapRender/Patches2/BackItem.cs
+++ b/WzComparerR2.MapRender/Patches2/BackItem.cs
@@ -23,8 +23,8 @@ namespace WzComparerR2.MapRender.Patches2
         public int ScreenMode { get; set; }
         public bool Flip { get; set; }
         public bool IsFront { get; set; }
+        public List<Tuple<int, int>> Quest { get; set; }
 
-        
         public ItemView View { get; set; }
 
         public static BackItem LoadFromNode(Wz_Node node)
@@ -35,7 +35,7 @@ namespace WzComparerR2.MapRender.Patches2
                 Ani = node.Nodes["ani"].GetValueEx<int>(0),
                 No = node.Nodes["no"].GetValueEx<string>(null),
                 SpineAni = node.Nodes["spineAni"].GetValueEx<string>(null),
-               
+
                 X = node.Nodes["x"].GetValueEx(0),
                 Y = node.Nodes["y"].GetValueEx(0),
                 Cx = node.Nodes["cx"].GetValueEx(0),
@@ -53,6 +53,15 @@ namespace WzComparerR2.MapRender.Patches2
             if (!string.IsNullOrWhiteSpace(backTags))
             {
                 item.Tags = backTags.Split(',').Select(tag => tag.Trim()).ToArray();
+            }
+            item.Quest = new List<Tuple<int, int>>();
+            if (node.Nodes["backTags"] != null)
+            {
+                int questID;
+                if (int.TryParse(node.Nodes["backTags"].GetValueEx<string>(null), out questID))
+                {
+                    item.Quest.Add(Tuple.Create(questID, 1));
+                }
             }
             return item;
         }

--- a/WzComparerR2.MapRender/Patches2/LifeItem.cs
+++ b/WzComparerR2.MapRender/Patches2/LifeItem.cs
@@ -19,6 +19,8 @@ namespace WzComparerR2.MapRender.Patches2
         public int Cy { get; set; }
         public int Rx0 { get; set; }
         public int Rx1 { get; set; }
+        public List<Tuple<int, int>> Quest { get; set; }
+        public List<Tuple<long, long>> Date { get; set; }
 
         public ItemView View { get; set; }
 
@@ -40,6 +42,35 @@ namespace WzComparerR2.MapRender.Patches2
                 Rx0 = node.Nodes["rx0"].GetValueEx(0),
                 Rx1 = node.Nodes["rx1"].GetValueEx(0)
             };
+            item.Quest = new List<Tuple<int, int>>();
+            item.Date = new List<Tuple<long, long>>();
+            if (item.Type == LifeType.Npc)
+            {
+                string path = $@"Npc\{item.ID:D7}.img";
+                var npcNode = PluginBase.PluginManager.FindWz(path);
+
+                int? npcLink = npcNode?.FindNodeByPath(@"info\link").GetValueEx<int>();
+                if (npcLink != null)
+                {
+                    path = $@"Npc\{npcLink.Value:D7}.img";
+                    npcNode = PluginBase.PluginManager.FindWz(path);
+                }
+
+                if (npcNode != null)
+                {
+                    foreach (Wz_Node conditionNode in npcNode.Nodes.Where(n => n.Text.StartsWith("condition")))
+                    {
+                        foreach (Wz_Node questNode in conditionNode.Nodes.Where(n => n.Text.All(char.IsDigit)))
+                        {
+                            item.Quest.Add(Tuple.Create(int.Parse(questNode.Text), Convert.ToInt32(questNode.Value)));
+                        }
+                        if (conditionNode.Nodes["dateStart"] != null || conditionNode.Nodes["dateEnd"] != null)
+                        {
+                            item.Date.Add(Tuple.Create(conditionNode.Nodes["dateStart"].GetValueEx<long>(0), conditionNode.Nodes["dateEnd"].GetValueEx<long>(0)));
+                        }
+                    }
+                }
+            }
             return item;
         }
 

--- a/WzComparerR2.MapRender/Patches2/ObjItem.cs
+++ b/WzComparerR2.MapRender/Patches2/ObjItem.cs
@@ -18,6 +18,8 @@ namespace WzComparerR2.MapRender.Patches2
         public bool Flip { get; set; }
         public bool Light { get; set; }
         public string SpineAni { get; set; }
+        public List<Tuple<int, int>> Quest { get; set; }
+        public List<Tuple<int, string, int>> Questex { get; set; }
 
         public ItemView View { get; set; }
 
@@ -44,6 +46,43 @@ namespace WzComparerR2.MapRender.Patches2
             {
                 item.Tags = objTags.Split(',').Select(tag => tag.Trim()).ToArray();
             }
+            item.Quest = new List<Tuple<int, int>>();
+            if (item.Tags != null)
+            {
+                int questID;
+                foreach (string tag in item.Tags)
+                {
+                    if (int.TryParse(tag, out questID) || (tag.StartsWith("q") && int.TryParse(tag.Substring(1), out questID)))
+                    {
+                        item.Quest.Add(Tuple.Create(questID, 1));
+                    }
+                }
+            }
+            if (node.Nodes["quest"] != null)
+            {
+                foreach (Wz_Node questNode in node.Nodes["quest"].Nodes)
+                {
+                    item.Quest.Add(Tuple.Create(int.Parse(questNode.Text), Convert.ToInt32(questNode.Value)));
+                }
+            }
+
+            item.Questex = new List<Tuple<int, string, int>>();
+            if (node.Nodes["questex"] != null)
+            {
+                foreach (Wz_Node qnodes in node.Nodes["questex"].Nodes)
+                {
+                    if (int.TryParse(qnodes.Text, out int questID))
+                    {
+                        Wz_Node knodes = qnodes.Nodes["key"];
+                        Wz_Node vnodes = qnodes.Nodes["value"];
+                        if (knodes != null && vnodes != null)
+                        {
+                            item.Questex.Add(Tuple.Create(questID, knodes.GetValueEx<string>(null), vnodes.GetValueEx<int>(-1)));
+                        }
+                    }
+                }
+            }
+
             return item;
         }
 

--- a/WzComparerR2.MapRender/Patches2/ParticleItem.cs
+++ b/WzComparerR2.MapRender/Patches2/ParticleItem.cs
@@ -14,6 +14,7 @@ namespace WzComparerR2.MapRender.Patches2
         public int Ry { get; set; }
         public int Z { get; set; }
         public SubParticleItem[] SubItems { get; set; }
+        public List<Tuple<int, int>> Quest { get; set; }
         public ItemView View { get; set; }
 
         public static ParticleItem LoadFromNode(Wz_Node node)
@@ -26,6 +27,15 @@ namespace WzComparerR2.MapRender.Patches2
                 Z = node.Nodes["z"].GetValueEx(0)
             };
 
+            item.Quest = new List<Tuple<int, int>>();
+            if (node.Nodes["quest"] != null)
+            {
+                foreach (Wz_Node questNode in node.Nodes["quest"].Nodes)
+                {
+                    item.Quest.Add(Tuple.Create(int.Parse(questNode.Text), Convert.ToInt32(questNode.Value)));
+                }
+            }
+
             var subItems = new List<SubParticleItem>();
             for (int i = 0; ; i++)
             {
@@ -34,13 +44,22 @@ namespace WzComparerR2.MapRender.Patches2
                 {
                     break;
                 }
-                subItems.Add(new SubParticleItem()
+                var subitem = new SubParticleItem()
                 {
                     X = subNode.Nodes["x"].GetValueEx(0),
                     Y = subNode.Nodes["y"].GetValueEx(0),
-                });
+                };
+                subitem.Quest = new List<Tuple<int, int>>();
+                if (subNode.Nodes["quest"] != null)
+                {
+                    foreach (Wz_Node questNode in subNode.Nodes["quest"].Nodes)
+                    {
+                        subitem.Quest.Add(Tuple.Create(int.Parse(questNode.Text), Convert.ToInt32(questNode.Value)));
+                    }
+                }
+                subItems.Add(subitem);
             }
-            
+
             if (subItems.Count <= 0)
             {
                 subItems.Add(new SubParticleItem()
@@ -57,6 +76,7 @@ namespace WzComparerR2.MapRender.Patches2
         {
             public int X { get; set; }
             public int Y { get; set; }
+            public List<Tuple<int, int>> Quest { get; set; }
         }
 
         public class ItemView

--- a/WzComparerR2.MapRender/ResourceLoader.cs
+++ b/WzComparerR2.MapRender/ResourceLoader.cs
@@ -22,6 +22,7 @@ namespace WzComparerR2.MapRender
             this.loadedAnimationData = new Dictionary<string, object>();
         }
 
+        public PatchVisibility PatchVisibility { get; set; }
         public IServiceProvider Services { get; protected set; }
 
         protected Dictionary<string, ResourceHolder> loadedItems;


### PR DESCRIPTION
I'm bringing a change from seotbeo's latest 2 commits [here](https://github.com/seotbeo/WzComparerR2/commit/6e2410c084763deab8e60703b83ec0ffcedb9d3c) and [here](https://github.com/seotbeo/WzComparerR2/commit/8e8cb5d9be6c6a233418e6428fae3d303371a1b4). The change adds the `/quest` (added prior to these 2 commits) and `/questex` options in MapRender, allowing you to toggle different Map settings based on quest / questex keys.

I recorded a showcase of the two options:
https://www.youtube.com/watch?v=mCPCJSWIwhg

The first map is Map ID 555002200, from MapleSEA v237.