### PR TITLE
Fix the issue where pressing key in SkillTooltip would freeze shortly

### DIFF
--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -2687,19 +2687,19 @@ namespace WzComparerR2
             {
                 case Keys.Escape:
                     frm.Hide();
-                    break;
+                    return;
                 case Keys.Up:
                     frm.Top -= 1;
-                    break;
+                    return;
                 case Keys.Down:
                     frm.Top += 1;
-                    break;
+                    return;
                 case Keys.Left:
                     frm.Left -= 1;
-                    break;
+                    return;
                 case Keys.Right:
                     frm.Left += 1;
-                    break;
+                    return;
             }
 
             Skill skill = frm.TargetItem as Skill;
@@ -2723,6 +2723,8 @@ namespace WzComparerR2
                     case Keys.OemCloseBrackets:
                         skill.Level += this.skillInterval;
                         break;
+                    default:
+                        return;
                 }
                 frm.Refresh();
             }


### PR DESCRIPTION
此问题是我在给自己的 JMS 版本实装翻译功能时发现的。对于 Skill Tooltip 而言，按下 Esc / 上下左右时，仍然会触发一次 Tooltip 刷新，然后才会关闭 Tooltip 或位移。按下其它未分配的按键也会触发 Tooltip 刷新。
在我的版本中，如果不这么调整，会导致每按一次按键，程序就会卡顿一次，开启翻译后问题会更为严重。