### PR TITLE
Add support for jewel 178

### DIFF
--- a/WzComparerR2.Common/CharaSim/Gear.cs
+++ b/WzComparerR2.Common/CharaSim/Gear.cs
@@ -378,6 +378,7 @@ namespace WzComparerR2.CharaSim
             {
                 case GearType.emblem:
                 case GearType.bit:
+                case GearType.jewel:
                 case (GearType)3: //发型
                     return 2;
             }

--- a/WzComparerR2.Common/CharaSim/GearType.cs
+++ b/WzComparerR2.Common/CharaSim/GearType.cs
@@ -505,6 +505,10 @@ namespace WzComparerR2.CharaSim
         /// </summary>
         totem = 120,
         /// <summary>
+        /// 珠宝 178
+        /// </summary>
+        jewel = 178,
+        /// <summary>
         /// 宠物装备 180
         /// </summary>
         petEquip = 180,

--- a/WzComparerR2.Common/CharaSim/ItemStringHelper.cs
+++ b/WzComparerR2.Common/CharaSim/ItemStringHelper.cs
@@ -360,6 +360,8 @@ namespace WzComparerR2.CharaSim
                 case GearType.chakram: return "环刃";
                 case GearType.hexSeeker: return "索魂器";
 
+                case GearType.jewel: return "珠宝";
+
                 default: return null;
             }
         }


### PR DESCRIPTION
这是 CMS v214 和 TMS v268 版本即将追加的新装备类型“珠宝”（内部名称为 jewel）。此 pr 支持了这一装备类别，而且修正了会意外显示性别的问题。
修正前：
![1780000(1)](https://github.com/user-attachments/assets/aa016902-9322-41b9-a4fd-721110ab3ddb)
修正后：
![1780000(2)](https://github.com/user-attachments/assets/5bb2aa9c-822e-4afe-b505-cded203c9e6d)
