### PR TITLE
Refactor: Improve error handling in DumpImage.lua Kagamia#325

### DIFF
--- a/WzComparerR2.LuaConsole/Examples/DumpImages.lua
+++ b/WzComparerR2.LuaConsole/Examples/DumpImages.lua
@@ -17,6 +17,7 @@ end
 local topWzPath = 'Character'
 local topNode = PluginManager.FindWz(topWzPath)
 local outputDir = "D:\\wzDump"
+local errorList = {}  -- collect error messages here
 
 ------------------------------------------------------------
 -- main function
@@ -33,45 +34,66 @@ for n in enumAllWzNodes(topNode) do
   local img = Wz_NodeExtension.GetNodeWzImage(n)
   
   if img then
-    --extract wz image
-    env:WriteLine('(extract)'..(img.Name))
-    if img:TryExtract() then
-    
-      local dir = outputDir.."\\"..(n.FullPathToFile)
-      local dirCreated = false
-      
-      --find all png
-      for n2 in enumAllWzNodes(img.Node) do
-        local png = n2.Value
-        if isPng(png) and (png.Width>1 or png.Height>1) then
-          
-          local fn = n2.FullPath:sub(img.Name:len()+2):gsub("\\", ".")
-          fn = removeInvalidPathChars(fn)
-          fn = Path.Combine(dir, fn .. ".png")
-          
-          --ensure dir exists
-          if not dirCreated then
-            if not Directory.Exists(dir) then
-              Directory.CreateDirectory(dir)
-            end
-            dirCreated = true
-          end
-          
-          --save as png
-          local bmp = png:ExtractPng()
-          bmp:Save(fn)
-          bmp:Dispose()
-          
-        end
-      end
-      
-      img:Unextract()
-    else --error
-      
-      env:WriteLine((img.Name)..' extract failed.')
-      
-    end --end extract
-  end -- end type validate
-end -- end foreach
+    env:WriteLine('(extract) ' .. (img.Name))
+    local success, extractErr = pcall(function()
+      if img:TryExtract() then
+        local dir = outputDir .. "\\" .. (n.FullPathToFile)
+        local dirCreated = false
 
-env:WriteLine('--------Done.---------')
+        for n2 in enumAllWzNodes(img.Node) do
+          local png = n2.Value
+          if isPng(png) and (png.Width > 1 or png.Height > 1) then
+            local fn = n2.FullPath:sub(img.Name:len() + 2):gsub("\\", ".")
+            fn = removeInvalidPathChars(fn)
+            fn = Path.Combine(dir, fn .. ".png")
+
+            if not dirCreated then
+              if not Directory.Exists(dir) then
+                Directory.CreateDirectory(dir)
+              end
+              dirCreated = true
+            end
+
+            -- Try saving PNG
+            local successSave, saveErr = pcall(function()
+              local bmp = png:ExtractPng()
+              if bmp then
+                bmp:Save(fn)
+                bmp:Dispose()
+              else
+                error("ExtractPng() returned nil.")
+              end
+            end)
+
+            if not successSave then
+              local errMsg = string.format("Error saving PNG [%s]: %s", n2.FullPath, saveErr)
+              env:WriteLine(errMsg)
+              table.insert(errorList, errMsg)
+            end
+          end
+        end
+        img:Unextract()
+      else
+        local errMsg = string.format("%s extract failed.", img.Name)
+        env:WriteLine(errMsg)
+        table.insert(errorList, errMsg)
+      end
+    end)
+
+    if not success then
+      local errMsg = string.format("Unexpected error in image [%s]: %s", img.Name, extractErr)
+      env:WriteLine(errMsg)
+      table.insert(errorList, errMsg)
+    end
+  end
+end
+
+-- Final error report
+if #errorList > 0 then
+  env:WriteLine("-------- Error Summary --------")
+  for i, err in ipairs(errorList) do
+    env:WriteLine(err)
+  end
+end
+
+env:WriteLine('-------- Done. --------')


### PR DESCRIPTION
Improved error handling to the DumpImages.lua script. If ExtractPng() fails (returns nil), the script will now log the error and continue processing instead of throwing an exception and halting execution.

### Before

- Script crashes with attempt to index a nil value if any image extraction fails.

```
====已经保存C:\WzComparerR2-Kagamia\WzComparerR2.LuaConsole\Examples\DumpImages.lua====
开始执行DumpImages.lua...
(extract)AllianceUI.img
...
(extract)UIToolTipNew.img
NLua.Exceptions.LuaScriptException: [string "chunk"]:62: attempt to index a nil value (local 'bmp')
```

### After

- Error is caught and logged.
- Execution continues for the remaining images.
- Summary of all failed extractions is printed at the end.

```
====已经保存C:\WzComparerR2-Kagamia\WzComparerR2.LuaConsole\Examples\DumpImages.lua====
开始执行DumpImages.lua...
(extract)AllianceUI.img
...
(extract) UIToolTipNew.img
Error saving PNG [UIToolTipNew.img\Item\Equip\particle\starForce\0\0]: [string "chunk"]:57: ExtractPng() returned nil.
Error saving PNG [UIToolTipNew.img\Item\Equip\particle\starForce\0\1]: [string "chunk"]:57: ExtractPng() returned nil.
Error saving PNG [UIToolTipNew.img\Item\Equip\particle\starForce\0\2]: [string "chunk"]:57: ExtractPng() returned nil.
Error saving PNG [UIToolTipNew.img\Item\Equip\particle\starForce\0\3]: [string "chunk"]:57: ExtractPng() returned nil.
Error saving PNG [UIToolTipNew.img\Item\Equip\particle\starForce\0\4]: [string "chunk"]:57: ExtractPng() returned nil.
Error saving PNG [UIToolTipNew.img\Item\Equip\particle\starForce\0\5]: [string "chunk"]:57: ExtractPng() returned nil.
(extract) UITotalMenu.img
...
(extract) tutorial.img
-------- Error Summary --------
Error saving PNG [UIToolTipNew.img\Item\Equip\particle\starForce\0\0]: [string "chunk"]:57: ExtractPng() returned nil.
Error saving PNG [UIToolTipNew.img\Item\Equip\particle\starForce\0\1]: [string "chunk"]:57: ExtractPng() returned nil.
Error saving PNG [UIToolTipNew.img\Item\Equip\particle\starForce\0\2]: [string "chunk"]:57: ExtractPng() returned nil.
Error saving PNG [UIToolTipNew.img\Item\Equip\particle\starForce\0\3]: [string "chunk"]:57: ExtractPng() returned nil.
Error saving PNG [UIToolTipNew.img\Item\Equip\particle\starForce\0\4]: [string "chunk"]:57: ExtractPng() returned nil.
Error saving PNG [UIToolTipNew.img\Item\Equip\particle\starForce\0\5]: [string "chunk"]:57: ExtractPng() returned nil.
-------- Done. --------
```