### PR TITLE
MapRender: Add support for obj movetype 6, 7, 8

### DIFF
--- a/WzComparerR2.MapRender/MapData.cs
+++ b/WzComparerR2.MapRender/MapData.cs
@@ -667,7 +667,8 @@ namespace WzComparerR2.MapRender
             var aniItem = resLoader.LoadAnimationData(path);
             obj.View = new ObjItem.ItemView()
             {
-                Animator = CreateAnimator(aniItem, obj.SpineAni)
+                Animator = CreateAnimator(aniItem, obj.SpineAni),
+                Flip = obj.Flip
             };
         }
 

--- a/WzComparerR2.MapRender/Patches2/ObjItem.cs
+++ b/WzComparerR2.MapRender/Patches2/ObjItem.cs
@@ -20,6 +20,7 @@ namespace WzComparerR2.MapRender.Patches2
         public int MoveW { get; set; }
         public int MoveH { get; set; }
         public int MoveP { get; set; }
+        public int MoveDelay { get; set; }
         public bool Flip { get; set; }
         public bool Light { get; set; }
         public string SpineAni { get; set; }
@@ -45,6 +46,7 @@ namespace WzComparerR2.MapRender.Patches2
                 MoveW = 0,
                 MoveH = 0,
                 MoveP = 5000,
+                MoveDelay = 0,
 
                 Flip = node.Nodes["f"].GetValueEx(false),
                 Light = node.Nodes["light"].GetValueEx<int>(0) != 0,
@@ -104,6 +106,7 @@ namespace WzComparerR2.MapRender.Patches2
                 item.MoveW = obj_node.Nodes["moveW"].GetValueEx(0);
                 item.MoveH = obj_node.Nodes["moveH"].GetValueEx(0);
                 item.MoveP = obj_node.Nodes["moveP"].GetValueEx(5000);
+                item.MoveDelay = obj_node.Nodes["moveDelay"].GetValueEx(0);
             }
 
             return item;
@@ -120,6 +123,11 @@ namespace WzComparerR2.MapRender.Patches2
             /// 动画资源。
             /// </summary>
             public object Animator { get; set; }
+
+            /// <summary>
+            /// Flip state of item.
+            /// </summary>
+            public bool Flip { get; set; }
         }
     }
 }


### PR DESCRIPTION
Implemented obj moveType 6, 7, 8 introduced in KMST 1187 (993267000, 993267001)

----
type 6: one way
![type6](https://github.com/user-attachments/assets/1e33ff82-6fb1-4bc7-bebb-e8927c596258)

type 7: back and forth
![type7](https://github.com/user-attachments/assets/76c1700f-e598-4141-a4be-2fc338e3c6ca)

type 8: back and forth with flip
![type8](https://github.com/user-attachments/assets/069dbb2b-d543-4cbb-8954-b888ba8efbfe)

src: https://youtu.be/ZJbgQLVnD8o?si=1TjNTsTfSQwu1_na&t=1174 , https://youtu.be/rlMQ0npZLcw?si=zPfdvUbAGFy1aeHG&t=955