### PR TITLE
Encoder: Use QuickTime mov for transparent background

### DIFF
--- a/WzComparerR2/FrmGifSetting.Designer.cs
+++ b/WzComparerR2/FrmGifSetting.Designer.cs
@@ -79,6 +79,13 @@
             this.labelX12 = new DevComponents.DotNetBar.LabelX();
             this.textBoxX3 = new DevComponents.DotNetBar.Controls.TextBoxX();
             this.labelX13 = new DevComponents.DotNetBar.LabelX();
+            this.btnPreset = new DevComponents.DotNetBar.ButtonX();
+            this.btnNonTransparentMP4Preset = new DevComponents.DotNetBar.ButtonItem();
+            this.btnGreenBackdropMP4Preset = new DevComponents.DotNetBar.ButtonItem();
+            this.btnBlueBackdropMP4Preset = new DevComponents.DotNetBar.ButtonItem();
+            this.btnTransparentMOVPreset = new DevComponents.DotNetBar.ButtonItem();
+            this.btnTransparentWebMPreset = new DevComponents.DotNetBar.ButtonItem();
+            this.btnDefaultPreset = new DevComponents.DotNetBar.ButtonItem();
             this.panelExMosaic.SuspendLayout();
             this.panelExColor.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.integerInput1)).BeginInit();
@@ -115,6 +122,59 @@
             this.labelX1.Size = new System.Drawing.Size(99, 16);
             this.labelX1.TabIndex = 0;
             this.labelX1.Text = "BackGroundColor";
+            //
+            // btnPreset
+            //
+            this.btnPreset.Location = new System.Drawing.Point(160, 6);
+            this.btnPreset.ColorTable = DevComponents.DotNetBar.eButtonColor.OrangeWithBackground;
+            this.btnPreset.Size = new System.Drawing.Size(56, 23);
+            this.btnPreset.AutoExpandOnClick = true;
+            this.btnPreset.Name = "btnPreset";
+            this.btnPreset.TabIndex = 4;
+            this.btnPreset.Text = "Preset";
+            this.btnPreset.SubItems.AddRange(new DevComponents.DotNetBar.BaseItem[] {
+            this.btnNonTransparentMP4Preset,
+            this.btnGreenBackdropMP4Preset,
+            this.btnBlueBackdropMP4Preset,
+            this.btnTransparentMOVPreset,
+            this.btnTransparentWebMPreset,
+            this.btnDefaultPreset});
+            //
+            // btnNonTransparentMP4Preset
+            //
+            this.btnNonTransparentMP4Preset.Name = "btnNonTransparentMP4Preset";
+            this.btnNonTransparentMP4Preset.Text = "NonTransparentMP4";
+            this.btnNonTransparentMP4Preset.Click += new System.EventHandler(this.btnNonTransparentMP4Preset_Click);
+            //
+            // btnGreenBackdropMP4Preset
+            //
+            this.btnGreenBackdropMP4Preset.Name = "btnGreenBackdropMP4Preset";
+            this.btnGreenBackdropMP4Preset.Text = "GreenBackdropMP4";
+            this.btnGreenBackdropMP4Preset.Click += new System.EventHandler(this.btnGreenBackdropMP4Preset_Click);
+            //
+            // btnBlueBackdropMP4Preset
+            //
+            this.btnBlueBackdropMP4Preset.Name = "btnBlueBackdropMP4Preset";
+            this.btnBlueBackdropMP4Preset.Text = "BlueBackdropMP4";
+            this.btnBlueBackdropMP4Preset.Click += new System.EventHandler(this.btnBlueBackdropMP4Preset_Click);
+            //
+            // btnTransparentMOVPreset
+            //
+            this.btnTransparentMOVPreset.Name = "btnTransparentMOVPreset";
+            this.btnTransparentMOVPreset.Text = "TransparentMOV";
+            this.btnTransparentMOVPreset.Click += new System.EventHandler(this.btnTransparentMOVPreset_Click);
+            //
+            // btnTransparentWebMPreset
+            //
+            this.btnTransparentWebMPreset.Name = "btnTransparentWebMPreset";
+            this.btnTransparentWebMPreset.Text = "TransparentWebM";
+            this.btnTransparentWebMPreset.Click += new System.EventHandler(this.btnTransparentWebMPreset_Click);
+            //
+            // btnDefaultPreset
+            //
+            this.btnDefaultPreset.Name = "btnDefaultPreset";
+            this.btnDefaultPreset.Text = "Default";
+            this.btnDefaultPreset.Click += new System.EventHandler(this.btnDefaultPreset_Click);
             // 
             // checkBoxX1
             // 
@@ -358,6 +418,7 @@
             this.panelExColor.Controls.Add(this.checkBoxX1);
             this.panelExColor.Controls.Add(this.labelX3);
             this.panelExColor.Controls.Add(this.slider1);
+            this.panelExColor.Controls.Add(this.btnPreset);
             this.panelExColor.DisabledBackColor = System.Drawing.Color.Empty;
             this.panelExColor.Enabled = false;
             this.panelExColor.Location = new System.Drawing.Point(80, 14);
@@ -852,5 +913,12 @@
         private DevComponents.DotNetBar.LabelX labelX12;
         private DevComponents.DotNetBar.Controls.TextBoxX textBoxX3;
         private DevComponents.DotNetBar.LabelX labelX13;
+        private DevComponents.DotNetBar.ButtonX btnPreset;
+        private DevComponents.DotNetBar.ButtonItem btnNonTransparentMP4Preset;
+        private DevComponents.DotNetBar.ButtonItem btnGreenBackdropMP4Preset;
+        private DevComponents.DotNetBar.ButtonItem btnBlueBackdropMP4Preset;
+        private DevComponents.DotNetBar.ButtonItem btnTransparentMOVPreset;
+        private DevComponents.DotNetBar.ButtonItem btnTransparentWebMPreset;
+        private DevComponents.DotNetBar.ButtonItem btnDefaultPreset;
     }
 }

--- a/WzComparerR2/FrmGifSetting.cs
+++ b/WzComparerR2/FrmGifSetting.cs
@@ -205,6 +205,63 @@ namespace WzComparerR2
             config.FFmpegOutputFileExtension = this.FFmpegDefaultExtension;
         }
 
+        private void btnNonTransparentMP4Preset_Click(object sender, EventArgs e)
+        {
+            GifEncoder = 3;
+            BackgroundType = ImageBackgroundType.Color;
+            BackgroundColor = Color.White;
+            textBoxX2.Clear();
+            textBoxX3.Clear();
+        }
+
+        private void btnGreenBackdropMP4Preset_Click(object sender, EventArgs e)
+        {
+            GifEncoder = 3;
+            BackgroundType = ImageBackgroundType.Color;
+            BackgroundColor = Color.FromArgb(0, 255, 0);
+            textBoxX2.Clear();
+            textBoxX3.Clear();
+        }
+
+        private void btnBlueBackdropMP4Preset_Click(object sender, EventArgs e)
+        {
+            GifEncoder = 3;
+            BackgroundType = ImageBackgroundType.Color;
+            BackgroundColor = Color.Blue;
+            textBoxX2.Clear();
+            textBoxX3.Clear();
+        }
+
+        private void btnTransparentMOVPreset_Click(object sender, EventArgs e)
+        {
+            GifEncoder = 3;
+            BackgroundType = ImageBackgroundType.Transparent;
+            slider1.Value = 0;
+            BackgroundColor = Color.White;
+            this.FFmpegArgument = @$"-y -f rawvideo -pixel_format bgra -s %w*%h -r 1000/%t -i ""%i"" -vf ""crop=trunc(iw/2)*2:trunc(ih/2)*2"" -vcodec qtrle -pix_fmt argb ""%o""";
+            this.FFmpegDefaultExtension = ".mov";
+        }
+
+        private void btnTransparentWebMPreset_Click(object sender, EventArgs e)
+        {
+            GifEncoder = 3;
+            BackgroundType = ImageBackgroundType.Transparent;
+            slider1.Value = 0;
+            BackgroundColor = Color.White;
+            this.FFmpegArgument = @$"-y -f rawvideo -pixel_format bgra -s %w*%h -r 1000/%t -i ""%i"" -vf ""crop=trunc(iw/2)*2:trunc(ih/2)*2"" -vcodec libvpx-vp9 -pix_fmt yuva420p ""%o""";
+            this.FFmpegDefaultExtension = ".webm";
+        }
+
+        private void btnDefaultPreset_Click(object sender, EventArgs e)
+        {
+            GifEncoder = 0;
+            BackgroundType = ImageBackgroundType.Transparent;
+            slider1.Value = 0;
+            BackgroundColor = Color.White;
+            textBoxX2.Clear();
+            textBoxX3.Clear();
+        }
+
         private void slider1_ValueChanged(object sender, EventArgs e)
         {
             var slider = sender as DevComponents.DotNetBar.Controls.Slider;


### PR DESCRIPTION
如果开启了透明背景，除非有另外指定参数，使用FFmpeg Encoder的时候，视频将会以QuickTime MOV格式导出。此时产生的文件体积虽然明显比MP4更大，但可以很方便的用于各种视频剪辑软件的素材，且不需要抠绿幕。
<img width="2220" height="1426" alt="image" src="https://github.com/user-attachments/assets/61470ba7-4480-4dff-a426-c0b8e3b56b9f" />