### PR TITLE
MapRender: support SpineNo of BackItem

### DIFF
--- a/WzComparerR2.MapRender/MapData.cs
+++ b/WzComparerR2.MapRender/MapData.cs
@@ -650,7 +650,7 @@ namespace WzComparerR2.MapRender
             {
                 case 0: aniDir = "back"; break;
                 case 1: aniDir = "ani"; break;
-                case 2: aniDir = "spine"; break;
+                case 2: aniDir = $"spine{back.SpineNo}"; break;
                 default: throw new Exception($"Unknown back ani value: {back.Ani}.");
             }
             string path = $@"Map\Back\{back.BS}.img\{aniDir}\{back.No}";

--- a/WzComparerR2.MapRender/Patches2/BackItem.cs
+++ b/WzComparerR2.MapRender/Patches2/BackItem.cs
@@ -12,6 +12,7 @@ namespace WzComparerR2.MapRender.Patches2
         public int Ani { get; set; }
         public string No { get; set; }
         public string SpineAni { get; set; }
+        public int? SpineNo { get; set; }
         public int X { get; set; }
         public int Y { get; set; }
         public int Cx { get; set; }
@@ -35,6 +36,7 @@ namespace WzComparerR2.MapRender.Patches2
                 Ani = node.Nodes["ani"].GetValueEx<int>(0),
                 No = node.Nodes["no"].GetValueEx<string>(null),
                 SpineAni = node.Nodes["spineAni"].GetValueEx<string>(null),
+                SpineNo = node.Nodes["spineNo"].GetValueEx<int?>(null),
 
                 X = node.Nodes["x"].GetValueEx(0),
                 Y = node.Nodes["y"].GetValueEx(0),


### PR DESCRIPTION
<img width="433" height="394" alt="스크린샷 2026-01-09 145625" src="https://github.com/user-attachments/assets/956bf5ae-9688-4a64-ab97-db875541b8ff" />
<img width="191" height="422" alt="스크린샷 2026-01-09 145656" src="https://github.com/user-attachments/assets/b855dd94-c087-43a2-b825-615d8cc70316" />

Handle `spineNo` of `BackItem` introduced around KMST 1197.