### PR TITLE
MapRender: Fix MSN map BGM play issue

### DIFF
--- a/WzComparerR2.MapRender/FrmMapRender.cs
+++ b/WzComparerR2.MapRender/FrmMapRender.cs
@@ -1194,7 +1194,7 @@ namespace WzComparerR2.MapRender
             string[] path = this.bgmName.Split('/');
             if (path.Length <= 1)
                 return;
-            path[0] += ".img";
+            path[0] += path[0].Contains(".img") ? "" : ".img";
 
             Wz_Node soundNode = soundWz.FindNodeByPath(true, true, path);
             Wz_Sound _sound = soundNode.GetValueEx<Wz_Sound>(null);

--- a/WzComparerR2.MapRender/FrmMapRender2.SceneManager.cs
+++ b/WzComparerR2.MapRender/FrmMapRender2.SceneManager.cs
@@ -218,7 +218,7 @@ namespace WzComparerR2.MapRender
             {
                 var path = new List<string>() { "Sound" };
                 path.AddRange(mapData.Bgm.Split('/'));
-                path[1] += ".img";
+                path[1] += path[1].Contains(".img") ? "" : ".img";
                 var bgmNode = PluginManager.FindWz(string.Join("\\", path));
                 if (bgmNode != null)
                 {

--- a/WzComparerR2.MapRender/FrmMapRender2.cs
+++ b/WzComparerR2.MapRender/FrmMapRender2.cs
@@ -760,7 +760,7 @@ namespace WzComparerR2.MapRender
                             {
                                 var path = new List<string>() { "Sound" };
                                 path.AddRange(this.mapData.Bgm.Split('/'));
-                                path[1] += ".img";
+                                path[1] += path[1].Contains(".img") ? "" : ".img";
                                 var bgmNode = PluginBase.PluginManager.FindWz(string.Join("\\", path));
                                 var subNodes = bgmNode?.Nodes ?? new Wz_Node.WzNodeCollection(null);
                                 this.ui.ChatBox.AppendTextHelp($"多重BGM: {subNodes.Count}");


### PR DESCRIPTION
MSN大量存在了BGM路径包含 .img 的BGM，结果就是BGM无法在MapRender被正常播放。
该pr修正了此问题。