### PR TITLE
MapRender: support moveNode

### DIFF
--- a/WzComparerR2.MapRender/FrmMapRender2.SceneRendering.cs
+++ b/WzComparerR2.MapRender/FrmMapRender2.SceneRendering.cs
@@ -920,10 +920,11 @@ namespace WzComparerR2.MapRender
             mesh.Z0 = obj.Z;
             mesh.Z1 = obj.Index;
 
-            if (obj.MoveW != 0 || obj.MoveH != 0)
+            if (obj.MoveNodes.Count > 0)
             {
                 mesh.Position += GetMovingObjPos(obj);
             }
+            mesh.Alpha = obj.View.Alpha;
             mesh.FlipX = obj.View.Flip;
 
             return mesh;
@@ -1091,34 +1092,59 @@ namespace WzComparerR2.MapRender
             double movingX = 0;
             double movingY = 0;
             double time = obj.View.Time;
+            double period;
+            float progress;
+            MoveNode curMoveNode = obj.View.CurrentMoveNode;
+            if (curMoveNode == null || curMoveNode.MoveP <= 0)
+            {
+                return Vector2.Zero;
+            }
             switch (obj.MoveType)
             {
                 case 1:
                 case 2: // line
-                    time *= Math.PI * 2 / obj.MoveP;
-                    movingX = obj.MoveW * Math.Cos(time);
-                    movingY = obj.MoveH * Math.Cos(time);
+                    time *= Math.PI * 2 / curMoveNode.MoveP;
+                    movingX = curMoveNode.MoveW * Math.Cos(time);
+                    movingY = curMoveNode.MoveH * Math.Cos(time);
                     break;
                 case 3: // circle
-                    time *= Math.PI * 2 / obj.MoveP;
-                    movingX = obj.MoveW * Math.Cos(time);
-                    movingY = obj.MoveH * Math.Sin(time);
+                    time *= Math.PI * 2 / curMoveNode.MoveP;
+                    movingX = curMoveNode.MoveW * Math.Cos(time);
+                    movingY = curMoveNode.MoveH * Math.Sin(time);
                     break;
 
-                case 6:
-                case 7:
-                case 8:
-                    int sign = -1;
-                    double freq = (double)(obj.MoveP + obj.MoveDelay) * 2;
-                    time = time % freq;
-                    if (time >= freq / 2)
+                case 6: // one-way
+                    period = (double)(curMoveNode.MoveDelay + curMoveNode.MoveP);
+                    time = time % obj.TotalMovePeriod - curMoveNode.StartTime;
+
+                    progress = MathHelper.Clamp((float)((time - curMoveNode.MoveDelay) / curMoveNode.MoveP), 0f, 1f);
+                    movingX = MathHelper.Lerp(0, curMoveNode.MoveW, progress) + curMoveNode.StartPos.X;
+                    movingY = MathHelper.Lerp(0, curMoveNode.MoveH, progress) + curMoveNode.StartPos.Y;
+
+                    // fade in/out
+                    float alphaProgress = 1;
+                    float fadeTime = Math.Min(curMoveNode.MoveP * 0.1f, 300f);
+                    if (curMoveNode.IsFirstNode && time <= curMoveNode.MoveDelay + fadeTime)
                     {
-                        time -= freq / 2;
+                        alphaProgress = MathHelper.Clamp((float)(time - curMoveNode.MoveDelay) / fadeTime, 0f, 1f);
+                    }
+                    else if (curMoveNode.IsLastNode && time >= curMoveNode.MoveDelay + curMoveNode.MoveP - fadeTime)
+                    {
+                        alphaProgress = MathHelper.Clamp((float)(curMoveNode.MoveDelay + curMoveNode.MoveP - time) / fadeTime, 0f, 1f);
+                    }
+                    obj.View.Alpha = (int)MathHelper.Lerp(0, 255, alphaProgress);
+                    break;
+
+                case 7: // back and forth
+                case 8:
+                    period = (double)(curMoveNode.MoveDelay + curMoveNode.MoveP) * 2;
+                    time = time % period;
+                    bool back = time >= period / 2;
+                    if (back)
+                    {
+                        time -= period / 2;
                         if (obj.MoveType == 8)
                             obj.View.Flip = !obj.Flip;
-
-                        if (obj.MoveType != 6)
-                            sign = +1;
                     }
                     else
                     {
@@ -1126,9 +1152,11 @@ namespace WzComparerR2.MapRender
                             obj.View.Flip = obj.Flip;
                     }
 
-                    movingX = (Math.Min(1, Math.Max(-1, (time - obj.MoveDelay) * -2 / obj.MoveP + 1)) * sign + 1) / 2 * obj.MoveW;
-                    movingY = (Math.Min(1, Math.Max(-1, (time - obj.MoveDelay) * -2 / obj.MoveP + 1)) * sign + 1) / 2 * obj.MoveH;
-
+                    progress = MathHelper.Clamp((float)((time - curMoveNode.MoveDelay) / curMoveNode.MoveP), 0f, 1f);
+                    if (back)
+                        progress = 1 - progress;
+                    movingX = MathHelper.Lerp(0, curMoveNode.MoveW, progress);
+                    movingY = MathHelper.Lerp(0, curMoveNode.MoveH, progress);
                     break;
 
                 default:

--- a/WzComparerR2.MapRender/MapData.cs
+++ b/WzComparerR2.MapRender/MapData.cs
@@ -687,7 +687,7 @@ namespace WzComparerR2.MapRender
         {
             string path = $@"Map\Obj\{obj.OS}.img\{obj.L0}\{obj.L1}\{obj.L2}";
             var aniItem = resLoader.LoadAnimationData(path);
-            obj.View = new ObjItem.ItemView()
+            obj.View = new ObjItem.ItemView(obj)
             {
                 Animator = CreateAnimator(aniItem, obj.SpineAni),
                 Flip = obj.Flip

--- a/WzComparerR2.MapRender/MeshBatcher.cs
+++ b/WzComparerR2.MapRender/MeshBatcher.cs
@@ -129,6 +129,8 @@ namespace WzComparerR2.MapRender
                 rect.X = -rect.Right;
             }
 
+            var alpha = mesh.Alpha < 255 ? (int)(frame.A0 * (mesh.Alpha / 255f)) : frame.A0;
+
             //兼容平铺
             if (mesh.TileRegion != null)
             {
@@ -149,7 +151,7 @@ namespace WzComparerR2.MapRender
                         Prepare(frame.Blend ? ItemType.Sprite_BlendAdditive : ItemType.Sprite);
                         sprite.Draw(frame.Texture, pos,
                             frame.AtlasRect,
-                            new Color(Color.White, frame.A0),
+                            new Color(Color.White, alpha),
                             0,
                             origin,
                             1,
@@ -167,7 +169,7 @@ namespace WzComparerR2.MapRender
                     Prepare(frame.Blend ? ItemType.Sprite_BlendAdditive : ItemType.Sprite);
                     sprite.Draw(frame.Texture, mesh.Position,
                         frame.AtlasRect,
-                        new Color(Color.White, frame.A0),
+                        new Color(Color.White, alpha),
                         0,
                         origin,
                         1,
@@ -627,6 +629,7 @@ namespace WzComparerR2.MapRender
                 mesh.Position = Vector2.Zero;
                 mesh.Z0 = 0;
                 mesh.Z1 = 0;
+                mesh.Alpha = 255;
                 mesh.FlipX = false;
                 mesh.TileRegion = null;
                 mesh.TileOffset = Vector2.Zero;

--- a/WzComparerR2.MapRender/MeshItem.cs
+++ b/WzComparerR2.MapRender/MeshItem.cs
@@ -12,6 +12,7 @@ namespace WzComparerR2.MapRender
         public Vector2 Position { get; set; }
         public int Z0 { get; set; }
         public int Z1 { get; set; }
+        public int Alpha { get; set; } = 255;
 
         //附加信息
         public bool FlipX { get; set; }

--- a/WzComparerR2.MapRender/Patches2/MoveNode.cs
+++ b/WzComparerR2.MapRender/Patches2/MoveNode.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WzComparerR2.MapRender.Patches2
+{
+    public class MoveNode
+    {
+        public MoveNode()
+        {
+        }
+
+        public int MoveW { get; set; }
+        public int MoveH { get; set; }
+        public int MoveP { get; set; }
+        public int MoveDelay { get; set; }
+
+        public Vector2 StartPos { get; set; }
+        public int StartTime { get; set; }
+        public int TotalPeriod => MoveP + MoveDelay;
+
+        public bool IsFirstNode => StartTime == 0;
+        public bool IsLastNode { get; set; }
+    }
+}

--- a/WzComparerR2.MapRender/Patches2/ObjItem.cs
+++ b/WzComparerR2.MapRender/Patches2/ObjItem.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Microsoft.Xna.Framework;
 using WzComparerR2.PluginBase;
 using WzComparerR2.WzLib;
 
@@ -17,16 +18,14 @@ namespace WzComparerR2.MapRender.Patches2
         public int Y { get; set; }
         public int Z { get; set; }
         public int MoveType { get; set; }
-        public int MoveW { get; set; }
-        public int MoveH { get; set; }
-        public int MoveP { get; set; }
-        public int MoveDelay { get; set; }
         public bool Flip { get; set; }
         public bool Light { get; set; }
         public string SpineAni { get; set; }
         public List<QuestInfo> Quest { get; private set; } = new List<QuestInfo>();
         public List<QuestExInfo> Questex { get; private set; } = new List<QuestExInfo>();
         public List<ItemEvent> Events { get; private set; } = new List<ItemEvent>();
+        public List<MoveNode> MoveNodes { get; private set; } = new List<MoveNode>();
+        public int TotalMovePeriod => MoveNodes.Count > 0 ? MoveNodes[MoveNodes.Count - 1].StartTime + MoveNodes[MoveNodes.Count - 1].TotalPeriod : 0;
 
         public ItemView View { get; set; }
 
@@ -44,10 +43,6 @@ namespace WzComparerR2.MapRender.Patches2
                 Z = node.Nodes["z"].GetValueEx(0),
 
                 MoveType = 0,
-                MoveW = 0,
-                MoveH = 0,
-                MoveP = 5000,
-                MoveDelay = 0,
 
                 Flip = node.Nodes["f"].GetValueEx(false),
                 Light = node.Nodes["light"].GetValueEx<int>(0) != 0,
@@ -121,10 +116,47 @@ namespace WzComparerR2.MapRender.Patches2
             if (obj_node != null)
             {
                 item.MoveType = obj_node.Nodes["moveType"].GetValueEx(0);
-                item.MoveW = obj_node.Nodes["moveW"].GetValueEx(0);
-                item.MoveH = obj_node.Nodes["moveH"].GetValueEx(0);
-                item.MoveP = obj_node.Nodes["moveP"].GetValueEx(5000);
-                item.MoveDelay = obj_node.Nodes["moveDelay"].GetValueEx(0);
+                if (item.MoveType > 0)
+                {
+                    var top_moveNode = obj_node.FindNodeByPath("moveNode");
+                    if (top_moveNode == null)
+                    {
+                        item.MoveNodes.Add(new MoveNode()
+                        {
+                            MoveW = obj_node.Nodes["moveW"].GetValueEx(0),
+                            MoveH = obj_node.Nodes["moveH"].GetValueEx(0),
+                            MoveP = obj_node.Nodes["moveP"].GetValueEx(5000),
+                            MoveDelay = obj_node.Nodes["moveDelay"].GetValueEx(0),
+                            StartPos = Vector2.Zero,
+                            StartTime = 0,
+                        });
+                    }
+                    else
+                    {
+                        Vector2 sp = Vector2.Zero;
+                        int st = 0;
+                        Wz_Node moveNode;
+                        for (int idx = 0; (moveNode = top_moveNode.FindNodeByPath(idx.ToString())) != null; idx++)
+                        {
+                            var mn = new MoveNode()
+                            {
+                                MoveW = moveNode.Nodes["moveW"].GetValueEx(0),
+                                MoveH = moveNode.Nodes["moveH"].GetValueEx(0),
+                                MoveP = moveNode.Nodes["moveP"].GetValueEx(5000),
+                                MoveDelay = moveNode.Nodes["moveDelay"].GetValueEx(0),
+                                StartPos = sp,
+                                StartTime = st,
+                            };
+                            item.MoveNodes.Add(mn);
+                            sp += new Vector2(mn.MoveW, mn.MoveH);
+                            st += mn.TotalPeriod;
+                        }
+                    }
+                    if (item.MoveNodes.Count > 0)
+                    {
+                        item.MoveNodes[item.MoveNodes.Count - 1].IsLastNode = true;
+                    }
+                }
             }
 
             return item;
@@ -132,6 +164,13 @@ namespace WzComparerR2.MapRender.Patches2
 
         public class ItemView
         {
+            public ItemView(ObjItem owner)
+            {
+                this.Owner = owner;
+            }
+
+            public ObjItem Owner { get; }
+
             /// <summary>
             /// 时间关联，单位为毫秒。
             /// </summary>
@@ -146,6 +185,27 @@ namespace WzComparerR2.MapRender.Patches2
             /// Flip state of item.
             /// </summary>
             public bool Flip { get; set; }
+
+            public int Alpha { get; set; } = 255;
+
+            public MoveNode CurrentMoveNode
+            {
+                get
+                {
+                    if (Owner.TotalMovePeriod > 0)
+                    {
+                        var t = Time % Owner.TotalMovePeriod;
+                        foreach (var moveNode in Owner.MoveNodes)
+                        {
+                            if (t < moveNode.StartTime + moveNode.TotalPeriod)
+                            {
+                                return moveNode;
+                            }
+                        }
+                    }
+                    return null;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
<img width="865" height="760" alt="movenode1" src="https://github.com/user-attachments/assets/cec251cf-a0ec-4eed-b373-413edccfb3c9" />
<img width="868" height="764" alt="movenode2" src="https://github.com/user-attachments/assets/8ff35132-389b-4104-9d37-602cc1ee1c01" />
Support moveNodes of moving objects, and fade in/out for moveType 6.